### PR TITLE
slurm_optimization_tests

### DIFF
--- a/config/hk26_config.py
+++ b/config/hk26_config.py
@@ -14,7 +14,7 @@ from um_to_healpix.util import has_dimensions, cube_cell_method_is_not_empty, cu
     invert_cube_sign, check_cube_time_length
 
 # Global config.
-output_vn = 'v6.2'
+output_vn = 'v6.4'
 deploy = 'dev'
 # Location of input files.
 dy3dir = Path('/gws/nopw/j04/kscale/DYAMOND3_reruns/')
@@ -67,9 +67,8 @@ chunks2d = {
     0: (4 ** 8, 12 * 4 ** 0),
 }
 
-# Much better for regional arrays if these have the same spatial chunks as 2d
 chunks3d = {
-    z: (t, 1, s)
+    z: (t, 5, s)
     for z, (t, s) in chunks2d.items()
 }
 

--- a/config/hk26_config.py
+++ b/config/hk26_config.py
@@ -14,13 +14,17 @@ from um_to_healpix.util import has_dimensions, cube_cell_method_is_not_empty, cu
     invert_cube_sign, check_cube_time_length
 
 # Global config.
-output_vn = 'v6.1'
+output_vn = 'v6.2'
 deploy = 'dev'
 # Location of input files.
 dy3dir = Path('/gws/nopw/j04/kscale/DYAMOND3_reruns/')
-weightsdir = Path('/gws/nopw/j04/hrcm/mmuetz/weights/')
+# hrcm GWS not available.
+# weightsdir = Path('/gws/nopw/j04/hrcm/mmuetz/weights/')
+# donedir = Path(f'/gws/nopw/j04/hrcm/mmuetz/slurm_done/{deploy}')
+
+weightsdir = Path('/work/scratch-nopw2/mmuetz/weightsdir')
 # Location of donefiles. Delete to rerun a particular task.
-donedir = Path(f'/gws/nopw/j04/hrcm/mmuetz/slurm_done/{deploy}')
+donedir = Path(f'/work/scratch-nopw2/mmuetz/donedir/{deploy}')
 
 # Defaults - can be overridden.
 slurm_config = dict(
@@ -29,7 +33,7 @@ slurm_config = dict(
     cpus_per_task=1,
     partition='standard',
     qos='standard',
-    time='24:00:00',
+    time='10:00:00',
     mem=100000,
     nconcurrent_tasks=40,
 )
@@ -130,8 +134,6 @@ time3d = pd.date_range('2020-01-20', '2021-03-01', freq='3h')
 #     key: (<short_name>, <long_name)
 #     val: MapItem or MultiMapItem
 name_map_2d = {
-    ('psl', 'air_pressure_at_mean_sea_level'): MapItem('air_pressure_at_sea_level'),
-    ('tas', 'air_temperature'): MapItem('air_temperature'),
     ('psl', 'air_pressure_at_mean_sea_level'): MapItem('air_pressure_at_sea_level'),
     ('tas', 'air_temperature'): MapItem('air_temperature'),
     # TODO: Why are these two missing? Can I replace them?

--- a/scripts/slurm_optimization_tests/regrid_benchmark.py
+++ b/scripts/slurm_optimization_tests/regrid_benchmark.py
@@ -91,15 +91,14 @@ class Benchmarker:
 
             regridder = LatLon2HealpixRegridder(method=method, nproc=nproc, **self.kwargs)
             da_hp = regridder.regrid(da, lonname, latname)
+
+            end = timer()
+
             if self.sim not in self.das:
                 self.das[self.sim] = da_hp
             else:
                 if not np.isclose(self.das[self.sim].values, da_hp.values).all():
                     breakpoint()
-
-
-
-            end = timer()
 
             self.output['runidx'].append(self.runidx)
             self.output['repidx'].append(i)

--- a/scripts/slurm_optimization_tests/regrid_benchmark.py
+++ b/scripts/slurm_optimization_tests/regrid_benchmark.py
@@ -1,0 +1,141 @@
+"""Purpose is to do a simple regrid for different sims/settings, and store the results to allow for benchmarking."""
+import sys
+from collections import defaultdict
+
+import iris
+from pathlib import Path
+from timeit import default_timer as timer
+
+from loguru import logger
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from um_to_healpix.latlon_to_healpix import gen_weights, LatLon2HealpixRegridder
+from um_to_healpix.um_slurm_control import find_dyamond3_pp_dates_to_paths
+from um_to_healpix.util import load_config
+from um_to_healpix.cube_to_da_mapping import DataArrayExtractor
+from um_to_healpix.um_process_tasks import regrid_da_to_healpix, weights_filename
+
+
+class Benchmarker:
+    def __init__(self, config_path, repeat=3):
+        self.runidx = 0
+        self.config_path = config_path
+        self.config_obj = load_config(config_path)
+        self.repeat = repeat
+
+        self.output = defaultdict(list)
+
+        self.sim = None
+        self.config = None
+        self.das = {}
+
+
+    def load(self, sim):
+        self.sim = sim
+        self.config = self.config_obj.processing_config[sim]
+        basedir = self.config['basedir']
+        # weightsdir = config['weightsdir']
+        weightsdir = Path('/work/scratch-nopw2/mmuetz/weightsdir')
+
+        zoom = self.config['max_zoom']
+
+        g2d = self.config['groups']['2d']
+        mapping_key = ('psl', 'air_pressure_at_mean_sea_level')
+        cube_map = g2d['name_map'][mapping_key]
+
+        dates_to_paths = find_dyamond3_pp_dates_to_paths(basedir)
+        first_date = sorted(dates_to_paths.keys())[0]
+        inpaths = dates_to_paths[first_date]
+
+        logger.info(f"Loading cubes for {first_date}...")
+        cubes = iris.load(inpaths)
+
+        # Standard extractor setup (p and z needed for 3D, but optional for 2D psl)
+        extractor = DataArrayExtractor(None, None)
+        da = extractor.extract_da(cube_map, cubes.extract(g2d['constraint']))
+
+        lonname = [c for c in da.coords if c.startswith('longitude')][0]
+        latname = [c for c in da.coords if c.startswith('latitude')][0]
+        add_cyclic = self.config.get('add_cyclic', True)
+        regional = self.config.get('regional', False)
+        self.weights_path = weightsdir / weights_filename(da, zoom, lonname, latname, add_cyclic, regional)
+        if not self.weights_path.exists():
+            logger.info(f'No weights for {da.name}, generating')
+            # chunks[-1] selects the spatial chunk.
+            chunks = g2d['chunks'][zoom]
+            gen_weights(da, weights_path=self.weights_path, zoom=zoom, lonname=lonname, latname=latname,
+                        add_cyclic=add_cyclic, regional=regional, regional_chunks=chunks[-1])
+        self.da = da.compute()
+        self.drop_vars = self.config['drop_vars']
+
+        self.kwargs = dict(
+            zoom_level=zoom,
+            add_cyclic=self.config.get('add_cyclic', True),
+            regional=self.config.get('regional', False),
+            weights = xr.load_dataset(self.weights_path),
+        )
+
+    def run(self, method, nproc=None):
+        self.runidx += 1
+        logger.info(f"{self.runidx=}, {method=}, {nproc=}, {self.repeat=}")
+        da = self.da
+        drop_vars_exists = list(set(self.drop_vars) & set(k for k in da.coords.keys()))
+        da = da.drop_vars(drop_vars_exists)
+        lonname = [c for c in da.coords if c.startswith('longitude')][0]
+        latname = [c for c in da.coords if c.startswith('latitude')][0]
+
+        for i in range(self.repeat):
+            start = timer()
+
+            regridder = LatLon2HealpixRegridder(method=method, nproc=nproc, **self.kwargs)
+            da_hp = regridder.regrid(da, lonname, latname)
+            if self.sim not in self.das:
+                self.das[self.sim] = da_hp
+            else:
+                if not np.isclose(self.das[self.sim].values, da_hp.values).all():
+                    breakpoint()
+
+
+
+            end = timer()
+
+            self.output['runidx'].append(self.runidx)
+            self.output['repidx'].append(i)
+            self.output['sim'].append(self.sim)
+            self.output['nproc'].append(nproc)
+            self.output['method'].append(method)
+            self.output['time'].append(end - start)
+
+    def disp_output(self):
+        df = pd.DataFrame(self.output)
+        print(df)
+        df_summary = df.groupby('runidx').agg({
+            'sim': 'first',
+            'method': 'first',
+            'nproc': 'first',
+            'time': ['min', 'max', 'mean'],
+        })
+        print(df_summary)
+
+        breakpoint()
+
+
+def main(config_path, sims):
+    benchmark = Benchmarker(config_path, 5)
+    for sim in sims:
+        benchmark.load(sim)
+        benchmark.run('easygems_delaunay')
+        for i, nproc in enumerate([1, 2, 4, 6, 8, 12]):
+            benchmark.run('easygems_delaunay_parallel', nproc)
+    benchmark.disp_output()
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 3:
+        print("Usage: python regrid_benchmark.py <config_path> <sim>")
+        sys.exit(1)
+    config_path = Path(sys.argv[1])
+    sims = sys.argv[2:]
+    main(config_path, sims)

--- a/src/um_to_healpix/latlon_to_healpix.py
+++ b/src/um_to_healpix/latlon_to_healpix.py
@@ -114,7 +114,12 @@ def gen_weights(da, weights_path, zoom=10, lonname='longitude', latname='latitud
     da_flat = da.stack(cell=(lonname, latname))
 
     logger.info('computing weights')
-    weights = egr.compute_weights_delaunay((da_flat[lonname].values, da_flat[latname].values), (hp_lon, hp_lat))
+    lon = da_flat[lonname].values
+    lat = da_flat[latname].values
+    # Points at -90 or 90 make this crash. Apply small offset.
+    # lat = np.where(lat == 90, 89.986, lat)
+    # lat = np.where(lat == -90, -89.986, lat)
+    weights = egr.compute_weights_delaunay((lon, lat), (hp_lon, hp_lat))
     logger.debug(weights)
     weights.to_netcdf(weights_path)
     logger.info(f'saved weights to {weights_path}')
@@ -123,21 +128,21 @@ def gen_weights(da, weights_path, zoom=10, lonname='longitude', latname='latitud
 class LatLon2HealpixRegridder:
     """Regrid (UM) lat/lon .pp files to healpix .nc"""
 
-    def __init__(self, weights_path, method='easygems_delaunay', zoom_level=10, add_cyclic=True, regional=False,
-                 regional_chunks=None):
+    def __init__(self, weights, method='easygems_delaunay', zoom_level=10, add_cyclic=True, regional=False,
+                 regional_chunks=None, nproc=None):
         """Initate a regridder for a particular method/zoom levels.
         """
-        if method not in ['easygems_delaunay', 'earth2grid']:
-            raise ValueError('method must be either easygems_delaunay or earth2grid')
+        if method not in ['easygems_delaunay', 'easygems_delaunay_parallel', 'earth2grid']:
+            raise ValueError('method must be either easygems_delaunay, easygems_delaunay_parallel or earth2grid')
         self.method = method
         self.zoom_level = zoom_level
         self.add_cyclic = add_cyclic
-        self.weights_path = weights_path
         self.regional = regional
         if self.regional:
             self.regional_chunks = regional_chunks
-        if method == 'easygems_delaunay':
-            self.weights = xr.load_dataset(self.weights_path)
+        if method.startswith('easygems_delaunay'):
+            self.weights = weights
+        self.nproc = nproc
 
     def regrid(self, da, lonname, latname):
         """Do the regridding - set up common data to allow looping over all dims that are not lat/lon
@@ -164,6 +169,8 @@ class LatLon2HealpixRegridder:
         logger.trace(f'  - {dim_len}')
         if self.method == 'easygems_delaunay':
             self._regrid_easygems_delaunay(da, dim_ranges, regridded_data, lonname, latname)
+        elif self.method == 'easygems_delaunay_parallel':
+            self._regrid_easygems_delaunay_parallel(da, dim_ranges, regridded_data, lonname, latname)
         elif self.method == 'earth2grid':
             self._regrid_earth2grid(da, dim_ranges, regridded_data, lonname, latname)
         coords = {**coords, 'cell': cells}
@@ -180,9 +187,9 @@ class LatLon2HealpixRegridder:
         daout.attrs['regrid_method'] = self.method
         return daout
 
-    def _regrid_easygems_delaunay(self, da, dim_ranges, regridded_data, lonname, latname, regional=False):
+    def _regrid_easygems_delaunay(self, da, dim_ranges, regridded_data, lonname, latname):
         """Use precomputed weights file to do Delaunay regridding."""
-        da_flat = da.stack(cell=(lonname, latname))
+        da_flat = da.stack(latloncell=(lonname, latname))
         if self.regional:
             _, _, icell = get_regional_cell_idx(get_extent(da, lonname, latname), self.zoom_level)
             _, _, ichunk = get_limited_healpix(get_extent(da, lonname, latname), self.zoom_level, self.regional_chunks)
@@ -199,11 +206,59 @@ class LatLon2HealpixRegridder:
                 # both index a full field. Use this fact to convert between them.
                 # We can get away with only allocating field once.
                 # !!! NOTE: MASSIVELY FASTER IF I PASS IN .values !!!
+                # It is faster to do da_flat[idx].values rather than da_flat.values[idx]
                 field[icell] = egr.apply_weights(da_flat[idx].values, **self.weights)
+
                 regridded_data[idx] = field[ichunk]
-                # raise Exception()
             else:
+                # It is faster to do da_flat[idx].values rather than da_flat.values[idx]
                 regridded_data[idx] = egr.apply_weights(da_flat[idx].values, **self.weights)
+
+    def _regrid_easygems_delaunay_apply_ufunc(self, da, dim_ranges, regridded_data, lonname, latname):
+        raise NotImplemented
+        da_flat = da.stack(latloncell=(lonname, latname))
+        # dask_data = dask.array.from_array(da_flat, chunks={"time": 1}, inline_array=False)
+        # da_lazy = xr.DataArray(dask_data, coords=da_flat.coords, dims=da_flat.dims, attrs=da_flat.attrs)
+
+        regridded_data[:] = xr.apply_ufunc(
+            egr.apply_weights,
+            da_flat,
+            kwargs=self.weights,
+            input_core_dims=[['latloncell']],  # The dimension to operate over
+            output_core_dims=[['cell']],  # The new dimension created by the function
+            vectorize=True,  # Mimics your loop over non-core dimensions
+            dask='parallelized',  # Optional: enables parallel execution if using Dask
+            output_dtypes=[da_flat.dtype],
+            dask_gufunc_kwargs={
+                'output_sizes': {'cell': self.weights['tgt_idx'].size}
+            }
+        )
+
+    def _regrid_easygems_delaunay_parallel(self, da, dim_ranges, regridded_data, lonname, latname):
+        from joblib import Parallel, delayed
+
+        if self.regional:
+            raise NotImplemented
+
+        da_flat = da.stack(latloncell=(lonname, latname))
+
+        # Strip metadata once to maximize speed
+        data_buffer = np.ascontiguousarray(da_flat.values)
+        # Ensure weights are numpy to avoid overhead in the loop
+        weights_np = {k: (v.values if hasattr(v, 'values') else v) for k, v in self.weights.items()}
+        weights_np['weights'] = weights_np['weights'].astype(np.float32)
+
+        def parallel_regrid(idx):
+            # egr.apply_weights releases the GIL during the sum/multiply
+            return egr.apply_weights(data_buffer[idx], **weights_np)
+
+        # Use 'threads' to avoid memory copying of the array
+        logger.debug(f'{self.nproc=}')
+        results = Parallel(n_jobs=self.nproc, prefer="threads")(
+            delayed(parallel_regrid)(idx) for idx in product(*dim_ranges)
+        )
+
+        regridded_data[:] = np.array(results).reshape(regridded_data.shape)
 
     def _regrid_earth2grid(self, da, dim_ranges, regridded_data, lonname, latname):
         """Use earth2grid (which uses torch) to do regridding."""

--- a/src/um_to_healpix/um_process_tasks.py
+++ b/src/um_to_healpix/um_process_tasks.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 import dask
 import dask.array
+import zarr
 from dask.distributed import LocalCluster
 import iris
 import iris.exceptions
@@ -421,7 +422,10 @@ class UMProcessTasks:
             s3=get_jasmin_s3(), check=False)
         logger.debug(store_url)
         logger.debug(ds_tpl)
-        ds_tpl.to_zarr(zarr_store, mode='w', compute=False, zarr_format=2, consolidated=True)
+        # Writing consolidated=True at this stage slows down this write a lot.
+        ds_tpl.to_zarr(zarr_store, mode='w', compute=False, zarr_format=2)
+        # Writing it after the fact is quick.
+        zarr.consolidate_metadata(zarr_store)
 
     def regrid(self, task):
         """Regrid all variables from lat/lon to healpix.

--- a/src/um_to_healpix/um_process_tasks.py
+++ b/src/um_to_healpix/um_process_tasks.py
@@ -63,16 +63,19 @@ def get_crs(zoom):
     )
 
 
-def regrid_da_to_healpix(da, zoom, short_name, long_name, weightsdir, drop_vars, add_cyclic=True,
+def regrid_da_to_healpix(da, zoom, short_name, long_name, weights, drop_vars, add_cyclic=True,
                          regional=False, regional_chunks=None):
     """Create a regridded DataArray at a given zoom level from the original lat/lon DataArray."""
     um_name = da.name
 
     lonname = [c for c in da.coords if c.startswith('longitude')][0]
     latname = [c for c in da.coords if c.startswith('latitude')][0]
-    weights_path = weightsdir / weights_filename(da, zoom, lonname, latname, add_cyclic, regional)
-    logger.trace(f'  - using weights: {weights_path}')
-    regridder = LatLon2HealpixRegridder(weights_path=weights_path, method='easygems_delaunay', zoom_level=zoom,
+    # weights_path = weightsdir / weights_filename(da, zoom, lonname, latname, add_cyclic, regional)
+    logger.trace(f'  - using weights: {weights}')
+
+    # regridder = LatLon2HealpixRegridder(weights=weights, method='easygems_delaunay', zoom_level=zoom,
+    #                                     add_cyclic=add_cyclic, regional=regional, regional_chunks=regional_chunks)
+    regridder = LatLon2HealpixRegridder(weights=weights, method='easygems_delaunay_parallel', nproc=6, zoom_level=zoom,
                                         add_cyclic=add_cyclic, regional=regional, regional_chunks=regional_chunks)
 
     # These have to be dropped before you cyclic pad *some* data arrays, or you will get a coord mismatch.
@@ -144,8 +147,8 @@ def healpix_da_to_zarr(da, url, group_name, group_time, regional, nan_checks=Fal
 def weights_filename(da, zoom, lonname, latname, add_cyclic, regional):
     lon0, lonN = da[lonname].values[[0, -1]]
     lat0, latN = da[latname].values[[0, -1]]
-    lonstr = f'({lon0.item():.3f},{lonN.item():.3f},{len(da[lonname])})'
-    latstr = f'({lat0.item():.3f},{latN.item():.3f},{len(da[latname])})'
+    lonstr = f'{lon0.item():.3f}_{lonN.item():.3f}_{len(da[lonname])}'
+    latstr = f'{lat0.item():.3f}_{latN.item():.3f}_{len(da[latname])}'
 
     return f'regrid_weights.hpz{zoom}.cyclic_lon={add_cyclic}.regional={regional}.lon={lonstr}.lat={latstr}.nc'
 
@@ -465,6 +468,9 @@ class UMProcessTasks:
             # extractor will handle these.
             for i, key in enumerate(name_map):
                 short_name, long_name = key
+                if short_name == 'mrso':
+                    # TODO!!!
+                    continue
                 msg = f'{(i + 1)}/{len(name_map)}: regridding {short_name}'
                 logger.info('=' * len(msg))
                 logger.info(msg)
@@ -474,8 +480,12 @@ class UMProcessTasks:
 
                 zoom = self.config['max_zoom']
                 # Do the regridding.
+                lonname = [c for c in da.coords if c.startswith('longitude')][0]
+                latname = [c for c in da.coords if c.startswith('latitude')][0]
+                weights_path = self.config['weightsdir'] / weights_filename(da, zoom, lonname, latname, add_cyclic, regional)
+                weights = xr.load_dataset(weights_path)
                 da_hp = regrid_da_to_healpix(da, zoom, short_name, long_name,
-                                             self.config['weightsdir'], self.drop_vars,
+                                             weights, self.drop_vars,
                                              add_cyclic,
                                              regional, regional_chunks=chunks[-1])
                 # Write this variable to the zarr store.

--- a/src/um_to_healpix/um_slurm_control.py
+++ b/src/um_to_healpix/um_slurm_control.py
@@ -34,9 +34,9 @@ SLURM_SCRIPT_ARRAY = """#!/bin/bash
 #SBATCH -o slurm/output/{job_name}_{config_key}_{date_string}_%A_%a.out
 #SBATCH -e slurm/output/{job_name}_{config_key}_{date_string}_%A_%a.err
 #SBATCH --comment={comment}
-#SBATCH --exclude=host1117,host1210,host1211,host1212,host1226,host1227,host1228,host1247,host1248,host1249,host1250
 {dependency}
 
+## #SBATCH --exclude=host1117,host1210,host1211,host1212,host1226,host1227,host1228,host1247,host1248,host1249,host1250
 # host1210-2, host1226-8 are silently failing :(.
 
 # These nodes repeatedly fail to be able to read the kscale GWS.
@@ -48,6 +48,8 @@ if ! ls /gws/nopw/j04/kscale > /dev/null 2>&1; then
     echo "ERROR: kscale GWS not accessible on $(hostname)! Exiting."
     exit 99
 fi
+
+export OMP_NUM_THREADS=1
 
 ARRAY_INDEX=${{SLURM_ARRAY_TASK_ID}}
 
@@ -260,6 +262,8 @@ def process(ctx, endtime, config_key):
         logger.info(f'Running {len(tasks)} tasks')
         slurm_script_path = write_tasks_slurm_job_array(ctx.obj['config'].slurm_config, config_key, tasks, 'regrid',
                                                         nconcurrent_tasks=nconcurrent_tasks,
+                                                        qos='high',
+                                                        cpus_per_task=6,
                                                         depends_on=create_jobid)
         logger.debug(slurm_script_path)
         if not ctx.obj['dry_run']:


### PR DESCRIPTION
Improve the performance of regridding by using multiple cores/`joblib` to parallelize over fields. Uses 6 cores/task (SLURM) which was found to give the best benefit. Tested over 83 jobs on N2560 simulation. See #3 for more detail.